### PR TITLE
Issue in `add station` functionality

### DIFF
--- a/pyradio/main.py
+++ b/pyradio/main.py
@@ -53,7 +53,7 @@ def shell():
 
     # No need to parse the file if we add station
     if args.add:
-        params = input("Enter the name: "), input("Enter the url: ")
+        params = raw_input("Enter the name: "), raw_input("Enter the url: ")
         with open(args.stations, 'a') as cfgfile:
             writter = csv.writer(cfgfile)
             writter.writerow(params)


### PR DESCRIPTION
Problem
-----------

Command to add a new station

```
--- ~ » pyradio -a                                                                                                1 ↵
Enter the name: chillectro
```
fails with the following

```
Enter the name: Chillectro
Traceback (most recent call last):
  File "/Users/signalpillar/.pyenv/versions/2.7.8/bin/pyradio", line 9, in <module>
    load_entry_point('pyradio==0.5.2', 'console_scripts', 'pyradio')()
  File "/Users/signalpillar/.pyenv/versions/2.7.8/lib/python2.7/site-packages/pyradio/main.py", line 34, in shell
    params = input("Enter the name: "), input("Enter the url: ")
  File "<string>", line 1, in <module>
NameError: name 'chillectro' is not defined
```

Solution
-----------

When reading user input for the station name and URL use `raw_input` function instead of `input`.
`input` expects a valid python expression to be entered.

It is easy to make it work if to quote name and URL of the station but expecting python expression is not recommended anyway.