### PR TITLE
Ability to set mplayer's default volume with command: "H"

### DIFF
--- a/pyradio/player.py
+++ b/pyradio/player.py
@@ -22,7 +22,7 @@ class Player(object):
         try:
             out = self.process.stdout
             while(True):
-                subsystemOut = out.readline().decode("utf-8", "ignore")
+                subsystemOut = out.readline().decode("utf-8")
                 if subsystemOut == '':
                     break
                 subsystemOut = subsystemOut.strip()
@@ -94,11 +94,18 @@ class Player(object):
     def volumeDown(self):
         pass
 
+    def volumeDefaultHalf(self):
+    pass
+
 
 class MpPlayer(Player):
     """Implementation of Player object for MPlayer"""
 
     PLAYER_CMD = "mplayer"
+
+    volumeDefaultHalved = False
+    if os.system("grep -R -s 'volume' '~/.mplayer/config'"):
+        volumeDefaultHalved = True
 
     def _buildStartOpts(self, streamUrl, playList=False):
         """ Builds the options to pass to subprocess."""
@@ -127,6 +134,15 @@ class MpPlayer(Player):
     def volumeDown(self):
         """ decrease mplayer's volume """
         self._sendCommand("/")
+
+    def volumeDefaultHalf(self):
+        """ set mplayer's volume default to 50% by editing config file.  else remove config edit """
+        if not self.volumeDefaultHalved:
+            os.system("echo 'volume=50' >> ~/.mplayer/config")
+            self.volumeDefaultHalved = True
+        else:
+            os.system("sed -i '/volume=50/d' ~/.mplayer/config")
+            self.volumeDefaultHalved = False
 
 
 class VlcPlayer(Player):
@@ -166,6 +182,8 @@ class VlcPlayer(Player):
     def volumeDown(self):
         """ decrease mplayer's volume """
         self._sendCommand("voldown\n")
+
+
 
 
 def probePlayer():

--- a/pyradio/player.py
+++ b/pyradio/player.py
@@ -22,7 +22,7 @@ class Player(object):
         try:
             out = self.process.stdout
             while(True):
-                subsystemOut = out.readline().decode("utf-8")
+                subsystemOut = out.readline().decode("utf-8", "ignore")
                 if subsystemOut == '':
                     break
                 subsystemOut = subsystemOut.strip()
@@ -95,8 +95,7 @@ class Player(object):
         pass
 
     def volumeDefaultHalf(self):
-    pass
-
+		pass
 
 class MpPlayer(Player):
     """Implementation of Player object for MPlayer"""
@@ -183,9 +182,7 @@ class VlcPlayer(Player):
         """ decrease mplayer's volume """
         self._sendCommand("voldown\n")
 
-
-
-
+		
 def probePlayer():
     """ Probes the multimedia players which are available on the host
     system."""


### PR DESCRIPTION
I didn't update the README with the new command, but I'd be glad to if you accept this pull request :)

`def volumeDefaultHalf(self):
        """ set mplayer's volume default to 50% by editing config file.  else remove config edit """
        if not self.volumeDefaultHalved:
            os.system("echo 'volume=50' >> ~/.mplayer/config")
            self.volumeDefaultHalved = True
        else:
            os.system("sed -i '/volume=50/d' ~/.mplayer/config")
            self.volumeDefaultHalved = False`

This allows the user to edit their config file to include 'volume=50' by pressing 'H'.  It's very helpful for Pocket CHIP users, where the volume defaults to 100% every time the station is changed (which is too loud).

I also made sure this won't add repeated lines to the config file:
`volumeDefaultHalved = False
    if os.system("grep -R -s 'volume' '~/.mplayer/config'"):
        volumeDefaultHalved = True`

All tests have run well.