### PR TITLE
Update main.py to handle empty lines in stations file

### DIFF
--- a/pyradio/main.py
+++ b/pyradio/main.py
@@ -62,6 +62,8 @@ def shell():
     with open(args.stations, 'r') as cfgfile:
         stations = []
         for row in csv.reader(filter(lambda row: row[0]!='#', cfgfile), skipinitialspace=True):
+            if not row:
+                continue
             name, url = [s.strip() for s in row]
             stations.append((name, url))
 


### PR DESCRIPTION
Currently, if there is a newline at the beginning of the csv file or at the end, `main.py` throws

```
Traceback (most recent call last):
  File "test.py", line 11, in <module>
    name, url = [s.strip() for s in row]
ValueError: not enough values to unpack (expected 2, got 0)
```

In order to ignore the empty `row`, a condition is added.