### PR TITLE
Make add option compatible with Python3

### DIFF
--- a/pyradio/main.py
+++ b/pyradio/main.py
@@ -3,7 +3,8 @@ import sys
 import curses
 import logging
 from argparse import ArgumentParser
-from os import path, getenv
+from os import path, getenv, mkdir
+from shutil import copyfile
 
 from .radio import PyRadio
 
@@ -27,10 +28,26 @@ def __configureLogger():
     # add ch to logger
     logger.addHandler(fh)
 
+
+def check_stations(usr, root):
+    ''' Reclocate a station.csv copy in user home for easy manage.
+        Ej not need sudo when you add new station, etc '''
+
+    if path.exists(path.join(usr, 'station.csv')):
+        return
+    else:
+        mkdir(usr)
+        copyfile(root, path.join(usr, 'station.csv'))
+
+
+usr_path = path.join(getenv('HOME', '~'), '.config', 'pyradio')
+root_path = path.join(path.dirname(__file__), 'stations.csv')
+check_stations(usr_path, root_path)
+
 DEFAULT_FILE = ''
-for p in [path.join(getenv('HOME', '~'), '.pyradio', 'stations.csv'),
+for p in [path.join(usr_path, 'station.csv'),
           path.join(getenv('HOME', '~'), '.pyradio'),
-          path.join(path.dirname(__file__), 'stations.csv')]:
+          root_path]:
     if path.exists(p) and path.isfile(p):
         DEFAULT_FILE = p
         break

--- a/pyradio/main.py
+++ b/pyradio/main.py
@@ -53,7 +53,10 @@ def shell():
 
     # No need to parse the file if we add station
     if args.add:
-        params = raw_input("Enter the name: "), raw_input("Enter the url: ")
+        if sys.version_info < (3, 0):
+            params = raw_input("Enter the name: "), raw_input("Enter the url: ")
+        else:
+            params = input("Enter the name: "), input("Enter the url: ")
         with open(args.stations, 'a') as cfgfile:
             writter = csv.writer(cfgfile)
             writter.writerow(params)


### PR DESCRIPTION
 When try add new station, you get:
```Traceback (most recent call last):
  File "/usr/lib64/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/nstefani/Codigo/pyradio/pyradio/main.py", line 85, in <module>
    shell()
  File "/home/nstefani/Codigo/pyradio/pyradio/main.py", line 56, in shell
    params = raw_input("Enter the name: "), raw_input("Enter the url: ")
NameError: name 'raw_input' is not defined
```
This is because raw_input is not a python3 function.