### PR TITLE
volumeUp: '+' and '=' on keyboard column

### DIFF
--- a/pyradio/radio.py
+++ b/pyradio/radio.py
@@ -240,7 +240,7 @@ class PyRadio(object):
             self.refreshBody()
             return
 
-        if char == ord('+'):
+        if char == ord('+') or char == ord('='):
             self.player.volumeUp()
             return
 


### PR DESCRIPTION
Using the keyboard column to increase volume is a burden since Sh-= (+) must be pressed
With this commit, '+' and '=' can be used, greatly enhancing user experience