### PR TITLE
mpv: Avoid "rm: cannot remove '/tmp/mpvsocket': No such file or directory"…

### DIFF
--- a/pyradio/player.py
+++ b/pyradio/player.py
@@ -99,7 +99,8 @@ class MpvPlayer(Player):
 
     PLAYER_CMD = "mpv"
 
-    os.system("rm /tmp/mpvsocket");
+    if os.path.exists('/tmp/mpvsocket'):
+        os.system("rm /tmp/mpvsocket");
 
     def _buildStartOpts(self, streamUrl, playList=False):
         """ Builds the options to pass to subprocess."""


### PR DESCRIPTION
… message

This will remove the message
    rm: cannot remove '/tmp/mpvsocket': No such file or directory
when mpv is the selected player