### PR TITLE
mpv: Use profile [pyradio]

### DIFF
--- a/pyradio/player.py
+++ b/pyradio/player.py
@@ -112,11 +112,11 @@ class MpvPlayer(Player):
         volume-max=300
         volume=50"""
 
-        home = expanduser("~")
-        if os.path.exists(home + "/.config/mpv/mpv.conf"):
-            with open(home + "/.config/mpv/mpv.conf") as f:
-                conf = f.read()
-            if "[pyradio]" in conf:
+        config_file = expanduser("~") + "/.config/mpv/mpv.conf"
+        if os.path.exists(config_file):
+            with open(config_file) as f:
+                config_string = f.read()
+            if "[pyradio]" in config_string:
                 return True
         return False
 

--- a/pyradio/player.py
+++ b/pyradio/player.py
@@ -102,6 +102,24 @@ class MpvPlayer(Player):
     if os.path.exists('/tmp/mpvsocket'):
         os.system("rm /tmp/mpvsocket");
 
+    def _configHasProfile(self):
+        """ Checks if mpv config has [pyradio] entry / profile.
+
+        Profile example:
+
+        [pyradio]
+        volume-max=300
+        volume=50"""
+
+        from os.path import expanduser
+        home = expanduser("~")
+        if os.path.exists(home + "/.config/mpv/mpv.conf"):
+            with open(home + "/.config/mpv/mpv.conf") as f:
+                conf = f.read()
+            if "[pyradio]" in conf:
+                return True
+        return False
+
     def _buildStartOpts(self, streamUrl, playList=False):
         """ Builds the options to pass to subprocess."""
 
@@ -127,6 +145,8 @@ class MpvPlayer(Player):
                 opts = [self.PLAYER_CMD, "--quiet", streamUrl, "--input-ipc-server=/tmp/mpvsocket"]
             else:
                 opts = [self.PLAYER_CMD, "--quiet", streamUrl, "--input-unix-socket=/tmp/mpvsocket"]
+        if self._configHasProfile():
+            opts.append("--profile=pyradio")
         return opts
 
     def mute(self):

--- a/pyradio/player.py
+++ b/pyradio/player.py
@@ -100,6 +100,12 @@ class MpvPlayer(Player):
 
     PLAYER_CMD = "mpv"
 
+    """ USE_PROFILE
+    -1 : not checked yet
+     0 : do not use
+     1 : use profile"""
+    USE_PROFILE = -1
+
     if os.path.exists('/tmp/mpvsocket'):
         os.system("rm /tmp/mpvsocket");
 
@@ -117,8 +123,8 @@ class MpvPlayer(Player):
             with open(config_file) as f:
                 config_string = f.read()
             if "[pyradio]" in config_string:
-                return True
-        return False
+                return 1
+        return 0
 
     def _buildStartOpts(self, streamUrl, playList=False):
         """ Builds the options to pass to subprocess."""
@@ -145,7 +151,10 @@ class MpvPlayer(Player):
                 opts = [self.PLAYER_CMD, "--quiet", streamUrl, "--input-ipc-server=/tmp/mpvsocket"]
             else:
                 opts = [self.PLAYER_CMD, "--quiet", streamUrl, "--input-unix-socket=/tmp/mpvsocket"]
-        if self._configHasProfile():
+        if self.USE_PROFILE == -1:
+            self.USE_PROFILE = self._configHasProfile()
+
+        if self.USE_PROFILE == 1:
             opts.append("--profile=pyradio")
         return opts
 

--- a/pyradio/player.py
+++ b/pyradio/player.py
@@ -2,6 +2,7 @@ import subprocess
 import threading
 import os
 import logging
+from os.path import expanduser
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +112,6 @@ class MpvPlayer(Player):
         volume-max=300
         volume=50"""
 
-        from os.path import expanduser
         home = expanduser("~")
         if os.path.exists(home + "/.config/mpv/mpv.conf"):
             with open(home + "/.config/mpv/mpv.conf") as f:


### PR DESCRIPTION
Checks existence of "[pyradio]" profile in ~/.config/mpv/mpv.conf and uses it if found
This is the way to set default volume (and maximum volume, for that matter)