### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyradio/browser.py
+++ b/pyradio/browser.py
@@ -568,7 +568,7 @@ class RadioBrowser(PyRadioStationsBrowser):
                         votes          : station votes
                         clickcount     : station clicks
                         country        : station country
-                        state          : statiob state
+                        state          : station state
                         language       : station language
                         codec          : station codec
                         encoding       : station encoding ('' means utf-8)
@@ -1973,7 +1973,7 @@ class RadioBrowserSearchWindow(object):
             # logger.error('DE order_part = "{}"'.format(order_part))
             if order_part:
                 ret['post_data']['order'] = order_part
-        ''' check for revrese order '''
+        ''' check for reverse order '''
         if self._widgets[3].checked:
             ret['post_data']['reverse'] = 'true'
 

--- a/pyradio/install.py
+++ b/pyradio/install.py
@@ -254,7 +254,7 @@ class PyRadioUpdate(object):
     def update_or_uninstall_on_windows(self, mode='update'):
         params = ('', '--sng-master', '--sng-devel', '--devel', '--master')
         isRunning()
-        ''' Creates BAT file to update or unisntall PyRadio on Windows'''
+        ''' Creates BAT file to update or uninstall PyRadio on Windows'''
         self._dir = os.path.join(os.path.expanduser('~'), 'tmp-pyradio')
         shutil.rmtree(self._dir, ignore_errors=True)
         os.makedirs(self._dir, exist_ok=True)

--- a/pyradio/player.py
+++ b/pyradio/player.py
@@ -1433,7 +1433,7 @@ class MpvPlayer(Player):
         executable_found = False
 
     if executable_found:
-        ''' items of this tupple are considered icy-title
+        ''' items of this tuple are considered icy-title
             and get displayed after first icy-title is received '''
         icy_tokens = ('icy-title: ', )
 
@@ -1724,7 +1724,7 @@ class MpvPlayer(Player):
             Eventually will be used for python 2 only
 
             Python 2 cannot correctly read icy-title from
-            the socket (unidoce issue), so it has to read
+            the socket (unicode issue), so it has to read
             it from stdout.
         '''
 
@@ -1801,7 +1801,7 @@ class MpPlayer(Player):
         executable_found = False
 
     if executable_found:
-        ''' items of this tupple are considered icy-title
+        ''' items of this tuple are considered icy-title
             and get displayed after first icy-title is received
         '''
         icy_tokens = ('ICY Info:', )
@@ -1990,7 +1990,7 @@ class VlcPlayer(Player):
             executable_found = False
 
     if executable_found:
-        ''' items of this tupple are considered icy-title
+        ''' items of this tuple are considered icy-title
             and get displayed after first icy-title is received '''
         icy_tokens = ('New Icy-Title=', )
 

--- a/pyradio/radio.py
+++ b/pyradio/radio.py
@@ -1001,7 +1001,7 @@ class PyRadio(object):
                     break
 
     def _give_me_a_search_class(self, operation_mode):
-        ''' get a search class for a givven operation mode
+        ''' get a search class for a given operation mode
             the class is returned in self.search
         '''
         try:
@@ -1873,7 +1873,7 @@ class PyRadio(object):
                      Enter|,|Right|,|l    |Apply selected theme.
                      Space            |Apply theme and make it default.
                      s                |Make theme default and close window.
-                     T                |Toggle theme trasparency.
+                     T                |Toggle theme transparency.
                      /| / |n| / |N        |Search, go to next / previous result.
                      Esc|,|q|,|Left|,|h     |Close window.
                      %_Player Keys_
@@ -3521,13 +3521,13 @@ class PyRadio(object):
             self.refreshBody()
 
     def _toggle_transparency(self, changed_from_config_window=False, force_value=None):
-        ''' Toggles theme trasparency.
+        ''' Toggles theme transparency.
 
             changed_from_config_window is used to inhibit toggling from within
             Config Window when 'T' is pressed.
 
-            force_value will set trasparency if True or False,
-            or toggle trasparency if None
+            force_value will set transparency if True or False,
+            or toggle transparency if None
         '''
         if self.ws.window_mode == self.ws.CONFIG_MODE and not changed_from_config_window:
             return
@@ -3726,7 +3726,7 @@ class PyRadio(object):
                             if logger.isEnabledFor(logging.DEBUG):
                                 logger.debug('detectUpdateThread: Asked to stop. Stoping...')
                             break
-                        ''' set new verion '''
+                        ''' set new version '''
                         if logger.isEnabledFor(logging.INFO):
                             logger.info('detectUpdateThread: Update available: {}'.format(last_tag))
                         a_lock.acquire()
@@ -3974,7 +3974,7 @@ class PyRadio(object):
 
     def _paste(self, playlist=''):
         if self._unnamed_register:
-            ''' ok, I have someting to paste '''
+            ''' ok, I have something to paste '''
 
             if playlist == '':
                 ''' paste to current playlist / register '''

--- a/pyradio/simple_curses_widgets.py
+++ b/pyradio/simple_curses_widgets.py
@@ -1601,7 +1601,7 @@ class SimpleCursesHorizontalPushButtons(object):
         '''The parent window of the widget.
         This is a window, not another widget.
         If not set (or invalid), the buttons will not be
-        vissible even if show() is called.
+        visible even if show() is called.
         '''
         return self._parent
 

--- a/pyradio/themes.py
+++ b/pyradio/themes.py
@@ -298,10 +298,10 @@ class PyRadioTheme(object):
         return ''
 
     def toggleTransparency(self, force_value=None):
-        """ Toggles theme trasparency.
+        """ Toggles theme transparency.
 
-            force_value will set trasparency if True or False,
-            or toggle trasparency if None
+            force_value will set transparency if True or False,
+            or toggle transparency if None
         """
         if force_value is None:
             self._transparent = not self._transparent
@@ -760,7 +760,7 @@ class PyRadioThemeSelector(object):
             self._win.move(sel, self._width - 2)
         except:
             pass
-        ''' display trasnparency indicator '''
+        ''' display transparency indicator '''
         if self._transparent:
             self._win.addstr(self._height-1, self._width - 4, '[T]', curses.color_pair(self._box_color_pair))
         else:

--- a/pyradio/window_stack.py
+++ b/pyradio/window_stack.py
@@ -374,14 +374,14 @@ class Window_Stack(Window_Stack_Constants):
         return
 
     def str_to_mode(self, stringToFind):
-        ''' return mode number when givven mode name '''
+        ''' return mode number when given mode name '''
         for item in self.MODE_NAMES.items():
             if item[1] == stringToFind:
                 return item[0]
         return -2
 
     def str_to_mode_tuple(self, stringToFind):
-        ''' return mode tuple when givven mode name '''
+        ''' return mode tuple when given mode name '''
         for item in self.MODE_NAMES.items():
             if item[1] == stringToFind:
                 return item

--- a/windows.md
+++ b/windows.md
@@ -67,7 +67,7 @@ The installation consists of three steps:
 
 If you don't already have **Python**, just get to its [Windows Downloads](https://www.python.org/downloads/windows/) page and download the latest **3.x** release.
 
-When the download is done, run its setup and select "*Custom Installation*" so that you can "*Add Python to environment varaibles*". You can refer to the following image to see the relevant setting.
+When the download is done, run its setup and select "*Custom Installation*" so that you can "*Add Python to environment variables*". You can refer to the following image to see the relevant setting.
 
 ![Python Installation](https://members.hellug.gr/sng/pyradio/python1.jpg)
 


### PR DESCRIPTION
There are small typos in:
- pyradio/browser.py
- pyradio/install.py
- pyradio/player.py
- pyradio/radio.py
- pyradio/simple_curses_widgets.py
- pyradio/themes.py
- pyradio/window_stack.py
- windows.md

Fixes:
- Should read `tuple` rather than `tupple`.
- Should read `given` rather than `givven`.
- Should read `transparency` rather than `trasparency`.
- Should read `visible` rather than `vissible`.
- Should read `version` rather than `verion`.
- Should read `variables` rather than `varaibles`.
- Should read `uninstall` rather than `unisntall`.
- Should read `unicode` rather than `unidoce`.
- Should read `transparency` rather than `trasnparency`.
- Should read `station` rather than `statiob`.
- Should read `something` rather than `someting`.
- Should read `reverse` rather than `revrese`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md