### PR TITLE
Fix link for Bagel Radio stream

### DIFF
--- a/pyradio/stations.csv
+++ b/pyradio/stations.csv
@@ -1,5 +1,5 @@
 # Find lots more stations at http://www.iheart.com,
-Alternative (BAGeL Radio - SomaFM),http://somafm.com/bagel.pls
+Alternative (BAGeL Radio),https://ais-sa3.cdnstream1.com/2606_128.aac
 Alternative (The Alternative Project),http://c9.prod.playlists.ihrhls.com/4447/playlist.m3u8
 American Roots (Boot Liquor - SomaFM),http://somafm.com/bootliquor.pls
 Celtic (ThistleRadio - SomaFM),http://somafm.com/thistle.pls


### PR DESCRIPTION
Bagel radio, from the default stations list, is no longer hosted at SomaFM. The current stream repeats an announcement that the station has moved. See https://bagelradio2.blogspot.com/.

New stream tested working.