### PR TITLE
Fix restore active theme when toggling transparency

### DIFF
--- a/pyradio/themes.py
+++ b/pyradio/themes.py
@@ -227,9 +227,6 @@ class PyRadioTheme(object):
         self._active_colors = deepcopy(self._read_colors)
         self._do_init_pairs()
         self._update_colors()
-        self.outerBodyWin.refresh()
-        self.bodyWin.refresh()
-        self.footerWin.refresh()
         # curses.start_color()
 
     def readAndApplyTheme(self, a_theme, print_errors=None, **kwargs):


### PR DESCRIPTION
Seems like these attrs belong to the Pyradio not PyradioTheme class.
Leaving these in causes an AttributeError when toggling theme transparency.
I looked at the git blame and saw these lines were added recently. 
Removing these lines bring the restoreActiveTheme function back to what it was.