### PR TITLE
corrected Radio 35 and added Radio 35 folk

### DIFF
--- a/pyradio/stations.csv
+++ b/pyradio/stations.csv
@@ -42,4 +42,6 @@ Echoes of Bluemars - Cryosleep,http://streams.echoesofbluemars.org:8000/cryoslee
 Echoes of Bluemars - Voices from Within,http://streams.echoesofbluemars.org:8000/voicesfromwithin.m3u
 Synphaera Radio (Space Music),https://somafm.com/synphaera.pls
 Radio Levač (Serbian Folk & Country),http://213.239.205.210:8046/stream
-Radio 35 (Serbian and English Pop, Folk, Country & Hits),http://stream.radio035.net:8010/listen.pls
+Radio 35 (Serbian and English Pop Folk Country & Hits),http://stream.radio035.net:8010/listen.pls?sid=1
+Radio 35 Folk,https://stream.astrasv.net:8030/listen.pls?sid=1
+


### PR DESCRIPTION
I found that stations.csv had a problem: the extra commas in the genre summary pushed the station URL over 2 columns from where it was supposed to be. I added Radio 35 folk as an extra treat.