### PR TITLE
Add everforest hard theme

### DIFF
--- a/pyradio/themes/everforest-hard.pyradio-theme
+++ b/pyradio/themes/everforest-hard.pyradio-theme
@@ -1,0 +1,43 @@
+# Main foreground and background
+Stations            #9DA9A0 #272E33 
+
+# Playing station text color
+# (background color will come from Stations)
+Active Station      #A7C080
+
+# Status bar foreground and background
+Status Bar            #D3C6AA #4F5B58
+
+# Normal cursor foreground and background
+Normal Cursor       #1E2326 #7FBBB3
+
+# Cursor foreground and background
+# when cursor on playing station
+Active Cursor       #1E2326 #A7C080
+
+# Cursor foreground and background
+# This is the Line Editor cursor
+Edit Cursor         #fbf1f2 #bfb9c6
+
+# Text color for extra function indication
+# and jump numbers within the status bar
+# (background color will come from Stations)
+Extra Func          #69a9a7
+
+# Text color for URL
+# (background color will come from Stations)
+PyRadio URL         #A7C080
+
+# Message window border foreground and background.
+# The background color can be left unset.
+# Please refer to the following link for more info
+# https://github.com/coderholic/pyradio#secondary-windows-background
+#
+Messages Border     #272E33
+
+# Theme Transparency
+# Values are:
+#   0: No transparency
+#   1: Theme is transparent
+#   2: Obey config setting (default)
+transparency        0

--- a/pyradio/themes/everforest-hard.pyradio-theme
+++ b/pyradio/themes/everforest-hard.pyradio-theme
@@ -33,7 +33,7 @@ PyRadio URL         #A7C080
 # Please refer to the following link for more info
 # https://github.com/coderholic/pyradio#secondary-windows-background
 #
-Messages Border     #272E33
+Messages Border     #9DA9A0
 
 # Theme Transparency
 # Values are:


### PR DESCRIPTION
Based on the [everforest theme](https://github.com/sainnhe/everforest). I used its main highlight colors (green and blue) + the general background and foreground.

Messages border uses the same color as the background to create invisible borders. This is the only personal change I believe.