### PR TITLE
update title logging directory info in pyradio.1

### DIFF
--- a/docs/pyradio.1
+++ b/docs/pyradio.1
@@ -1725,7 +1725,7 @@ by pressing "\fBW\fR" while in the \fBMain\fR, the \fBPlaylist\fR or the \fBRegi
 
 .RE
 
-The titles are written in a file called \fIpyradio-titles.log\fR which is saved at \fBpyradio\fR configuration directory.
+The titles are written in a file called \fIpyradio-titles.log\fR which is located in the \fBRecordings Directory\fR.
 
 Log file sample:
 


### PR DESCRIPTION
`index.md` and `index.html` already has up-to-date information. this got left behind