### PR TITLE
add option to disable automatic updating of `stations.csv`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1952,7 +1952,7 @@ If a profile is set for the station, a “<strong>[P]</strong>” will be displa
 <p>When the package’s “<em>stations.csv</em>” files is updated, the changes it has will not automatically appear in the user’s stations file.</p>
 <p><strong>PyRadio</strong> will display a message asking the user to either update the file, ignore the changes for this version or postpone his decision for the next time <strong>PyRadio</strong> will be executed.</p>
 <p><a href="https://members.hellug.gr/sng/pyradio/pyradio-stations-update.png" target="_blank"><img src="https://members.hellug.gr/sng/pyradio/pyradio-stations-update.png" alt="PyRadio stations update" /></a></p>
-
+<p>This update can be disabled permanently by setting the configuration option "<em>auto_update_stations</em>" to <em>False</em> in the user's configuration file.</p>
 <p>Either way, the user can always manually update his <strong>stations file</strong>, by issuing the following command:</p>
 <pre>pyradio -us</pre>
 <p>If changes have been applied, a message resembling the following will appear:</p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -533,6 +533,8 @@ When the package's "*stations.csv*" files is updated, the changes it has will no
 
 ![PyRadio stations update](https://members.hellug.gr/sng/pyradio/pyradio-stations-update.png)
 
+This update can be disabled permanently by setting the configuration option "_auto\_update\_stations_" to _False_ in the user's configuration file.
+
 Either way, the user can always manually update his **stations file**, by issuing the following command:
 
 ```

--- a/pyradio/config
+++ b/pyradio/config
@@ -237,6 +237,14 @@ force_http = False
 # Default value = 0
 buffering = 0
 
+# Automatic stations.csv updates
+# If this option is True, PyRadio will automatically check for and
+# update the stations.csv file when a new version is available.
+# If False, you will need to manually update with "pyradio -us"
+#
+# Default value: True
+auto_update_stations = True
+
 # MPlayer auto update bitrate
 # This option is only relevant if MPlayer is installed.
 # In this case, if the station's bitrate is different to 128kbps,

--- a/pyradio/config.py
+++ b/pyradio/config.py
@@ -1380,6 +1380,7 @@ class PyRadioConfig(PyRadioStations):
         self.opts['shortcuts_keys'] = ['Shortcuts', '-']
         self.opts['localized_keys'] = ['Localized Shortcuts', '-']
         self.opts['online_header'] = ['Online services', '']
+        self.opts['auto_update_stations'] = ['Auto update stations: ', True]
         self.opts['radiobrowser'] = ['RadioBrowser', '-']
         self.opts['requested_player'] = ['', '']
         self.opts['dirty_config'] = ['', False]
@@ -1579,6 +1580,17 @@ class PyRadioConfig(PyRadioStations):
         except ValueError:
             self.opts['buffering'][1] = '0'
         if old_val != self.opts['buffering'][1]:
+            self.dirty_config = True
+
+    @property
+    def auto_update_stations(self):
+        return self.opts['auto_update_stations'][1]
+
+    @auto_update_stations.setter
+    def auto_update_stations(self, val):
+        old_val = self.opts['auto_update_stations'][1]
+        self.opts['auto_update_stations'][1] = val
+        if old_val != val:
             self.dirty_config = True
 
     @property
@@ -2836,6 +2848,11 @@ class PyRadioConfig(PyRadioStations):
                 if not (b == 0 or 5 <= b <= 60):
                     b = 0
                 self.opts['buffering'][1] = str(b)
+            elif sp[0] == 'auto_update_stations':
+                if sp[1].lower() == 'false':
+                    self.opts['auto_update_stations'][1] = False
+                else:
+                    self.opts['auto_update_stations'][1] = True
 
             elif sp[0] == 'localized_keys':
                 # logger.error(f'{sp[1] = }')

--- a/pyradio/config_window.py
+++ b/pyradio/config_window.py
@@ -157,6 +157,7 @@ class PyRadioConfigWindow():
     _help_text.append(['This options will open the configuration window for the Shortcuts Definitions.', '|', 'Please keep in mind that if you customize the keyboard shortcuts, the documentation may no longer align with your personalized settings. While the in-program runtime help will always reflect your current key configurations, the static documentation will continue to display the default shortcuts.', '|', 'To ensure you have the best experience, refer to the runtime help for the most accurate information regarding your customized key bindings!'])
     _help_text.append(['The "Localized Shortcuts" option allows you to define and customize keyboard shortcuts based on your preferred language. This feature enhances your experience by providing a seamless way to interact with the program in your chosen language.', '|', 'You can choose a language name from the list to load the corresponding character mapping file. This file contains the relationship between English letters (A-Z, a-z) and the letters used in your selected language.', '|', 'If the language does not exit, you will be able to create it.'])
     _help_text.append(None)
+    _help_text.append(['If enabled, PyRadio will automatically check online for updates to the stations.csv file and perform an update when a new version is available.', '|', 'If False, you will need to manually update with "pyradio -us"', '|', 'Default value: True'])
     _help_text.append(['This options will open the configuration window for the RadioBrowser Online Stations Directory.',])
 
     def __init__(
@@ -1404,6 +1405,7 @@ class PyRadioConfigWindow():
                 'enable_tts',
                 'tts_speak_volume_change_start',
                 'use_os_media_controls',
+                'auto_update_stations'
             ):
                 self._config_options[sel][1] = not self._config_options[sel][1]
                 # # if sel == 'open_last_playlist':

--- a/pyradio/radio.py
+++ b/pyradio/radio.py
@@ -2269,7 +2269,11 @@ effectively putting <b>PyRadio</b> in <span style="font-weight:bold; color: Gree
                         self._update_notification_thread.start()
 
             ''' check if stations.csv is updated '''
-            if self._cnf.locked:
+            if not self._cnf.auto_update_stations:
+                self._update_stations_thread = None
+                if logger.isEnabledFor(logging.INFO):
+                    logger.info('(detectUpdateStationsThread): not starting; auto updates are disabled!!!')
+            elif self._cnf.locked:
                 self._update_stations_thread = None
                 if logger.isEnabledFor(logging.INFO):
                     logger.info('(detectUpdateStationsThread): not starting; session is locked!!!')


### PR DESCRIPTION
### Add option to disable automatic updating of `stations.csv`

#### Motivation
On ephemeral systems with deterministic, pre-defined configurations, users are repeatedly prompted at every startup as to whether they wish to update the `stations.csv` file. It would be better if this update check could be disabled in the configuration file as to avoid unnecessary prompts and network checks for such users.

#### Changes
- Introduced a new configuration option, `auto_update_stations` (default: `true`).
- When set to `true`, the current behaviour is preserved: `PyRadio` checks for and prompts users to update the `stations.csv` file.
- When set to `false`, the update check is bypassed. The user must either:
  - Manually update the file using the command `pyradio -us`, or
  - Change the configuration to re-enable automatic updates.

#### Testing
Tested on `PyRadio` versions:
- 0.9.3.11.28
- 0.9.3.11.27